### PR TITLE
fix(object-member): support numeric name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 
 script:
 - yarn lint
-- yarn test --verbose
+- yarn test --verbose --runInBand
 
 after_script:
 - codecov

--- a/src/__tests__/__snapshots__/parse.ts.snap
+++ b/src/__tests__/__snapshots__/parse.ts.snap
@@ -189,5 +189,8 @@ import xyz = require(\\"xyz\\");
 type X = A[B[C]];
 type TypeName<T> = T extends string ? \\"string\\" : T extends number ? \\"number\\" : T extends boolean ? \\"boolean\\" : T extends undefined ? \\"undefined\\" : T extends Function ? \\"function\\" : \\"object\\";
 type ReturnType<T> = T extends (...args: any[]) => infer R ? R : T;
+type X = {
+    0: 123;
+};
 "
 `;

--- a/src/__tests__/parse.ts
+++ b/src/__tests__/parse.ts
@@ -141,6 +141,10 @@ type TypeName<T> =
     "object";
 
 type ReturnType<T> = T extends (...args: any[]) => infer R ? R : T;
+
+type X = {
+  0: 123
+}
 `;
 
 it('should return correctly', () => {

--- a/src/declarations/__tests__/__snapshots__/enum-declaration.ts.snap
+++ b/src/declarations/__tests__/__snapshots__/enum-declaration.ts.snap
@@ -29,3 +29,9 @@ exports[`should return correctly with name, members 1`] = `
     c = \\"hello\\"
 }"
 `;
+
+exports[`should return correctly with numerical member name 1`] = `
+"declare enum E {
+    0 = 0
+}"
+`;

--- a/src/declarations/__tests__/enum-declaration.ts
+++ b/src/declarations/__tests__/enum-declaration.ts
@@ -88,6 +88,21 @@ it('should return correctly with name, export, members', () => {
   ).toMatchSnapshot();
 });
 
+it('should return correctly with numerical member name', () => {
+  expect(
+    emit(
+      create_enum_declaration({
+        name: 'E',
+        members: [
+          create_variable_declaration({
+            name: 0,
+          }),
+        ],
+      }),
+    ),
+  ).toMatchSnapshot();
+});
+
 it('should throw error with members (VariableDeclaration with type (not undefined or LiteralType))', () => {
   expect(() =>
     emit(

--- a/src/declarations/enum-declaration.ts
+++ b/src/declarations/enum-declaration.ts
@@ -6,7 +6,7 @@ import {
   IElement,
   IElementOptions,
 } from '../element';
-import { add_declare_modifier_if_need } from '../utils';
+import { add_declare_modifier_if_need, is_valid_identifier } from '../utils';
 import { IVariableDeclaration } from './variable-declaration';
 
 export interface IEnumDeclarationOptions extends IElementOptions {
@@ -69,7 +69,12 @@ export const transform_enum_declaration = (
         counter = value + 1;
       }
       return ts.createEnumMember(
-        /* name        */ variable_declaration.name,
+        /* name        */ typeof variable_declaration.name === 'string' &&
+        is_valid_identifier(variable_declaration.name)
+          ? variable_declaration.name
+          : (ts.createLiteral(variable_declaration.name) as
+              | ts.StringLiteral
+              | ts.NumericLiteral),
         /* initializer */ ts.createLiteral(value),
       );
     }),

--- a/src/declarations/variable-declaration.ts
+++ b/src/declarations/variable-declaration.ts
@@ -11,7 +11,10 @@ import { transform } from '../transform';
 import { add_declare_modifier_if_need } from '../utils';
 
 export interface IVariableDeclarationOptions extends IElementOptions {
-  name: string;
+  name:
+    | string
+    // for object member
+    | number;
   type?: IType;
   export?: boolean;
   const?: boolean;
@@ -52,7 +55,9 @@ export const transform_variable_declaration = (
       path,
     ),
     /* declarationList */ ts.createVariableDeclarationList(
-      /* declarations  */ [ts.createVariableDeclaration(element.name, type)],
+      /* declarations  */ [
+        ts.createVariableDeclaration(element.name.toString(), type),
+      ],
       /* flags         */ element.const === true
         ? ts.NodeFlags.Const
         : element.let === true ? ts.NodeFlags.Let : undefined,

--- a/src/members/class-member.ts
+++ b/src/members/class-member.ts
@@ -73,9 +73,12 @@ export const transform_class_member = (
       return ts.createProperty(
         /* decorators    */ undefined,
         /* modifiers     */ modifiers,
-        /* name          */ is_valid_identifier(element.owned.name)
+        /* name          */ typeof element.owned.name === 'string' &&
+        is_valid_identifier(element.owned.name)
           ? element.owned.name
-          : ts.createLiteral(element.owned.name),
+          : (ts.createLiteral(element.owned.name) as
+              | ts.StringLiteral
+              | ts.NumericLiteral),
         /* questionToken */ question_token,
         /* type          */ transform(
           element.owned.type || any_type,

--- a/src/members/object-member.ts
+++ b/src/members/object-member.ts
@@ -52,9 +52,12 @@ export const transform_object_member = (
     case ElementKind.VariableDeclaration:
       return ts.createPropertySignature(
         /* modifiers     */ modifiers,
-        /* name          */ is_valid_identifier(element.owned.name)
+        /* name          */ typeof element.owned.name === 'string' &&
+        is_valid_identifier(element.owned.name)
           ? element.owned.name
-          : ts.createLiteral(element.owned.name),
+          : (ts.createLiteral(element.owned.name) as
+              | ts.StringLiteral
+              | ts.NumericLiteral),
         /* questionToken */ question_token,
         /* type          */ transform(
           element.owned.type || any_type,

--- a/src/parsers/property-signature.ts
+++ b/src/parsers/property-signature.ts
@@ -9,7 +9,10 @@ export const parse_property_signature = (
 ): IObjectMember =>
   create_object_member({
     owned: create_variable_declaration({
-      name: (node.name as ts.Identifier).text,
+      name:
+        node.name.kind === ts.SyntaxKind.NumericLiteral
+          ? +(node.name as ts.NumericLiteral).text
+          : (node.name as ts.Identifier).text,
       type: if_defined(node.type, parse_native),
     }),
     readonly: has_kind(node.modifiers, ts.SyntaxKind.ReadonlyKeyword),

--- a/src/types/__tests__/__snapshots__/object-type.ts.snap
+++ b/src/types/__tests__/__snapshots__/object-type.ts.snap
@@ -6,3 +6,9 @@ exports[`should return correctly 1`] = `
     [key: string]: any;
 }"
 `;
+
+exports[`should return correctly with numerical name 1`] = `
+"{
+    0: any;
+}"
+`;

--- a/src/types/__tests__/object-type.ts
+++ b/src/types/__tests__/object-type.ts
@@ -1,4 +1,5 @@
 import { string_type } from '../../constants';
+import { create_variable_declaration } from '../../declarations';
 import { create_function_declaration } from '../../declarations/function-declaration';
 import { create_parameter_declaration } from '../../declarations/parameter-declaration';
 import { emit } from '../../emit';
@@ -20,6 +21,22 @@ it('should return correctly', () => {
             parameter: create_parameter_declaration({
               name: 'key',
               type: string_type,
+            }),
+          }),
+        ],
+      }),
+    ),
+  ).toMatchSnapshot();
+});
+
+it('should return correctly with numerical name', () => {
+  expect(
+    emit(
+      create_object_type({
+        members: [
+          create_object_member({
+            owned: create_variable_declaration({
+              name: 0,
             }),
           }),
         ],


### PR DESCRIPTION
Before

```ts
dts.emit(dts.parse_type("{ 0: 1 }")) //=> { "0": 1 }
```

After

```ts
dts.emit(dts.parse_type("{ 0: 1 }")) //=> { 0: 1 }
```